### PR TITLE
Atualiza identidade visual e componentes

### DIFF
--- a/IdentidadeVisual.md
+++ b/IdentidadeVisual.md
@@ -1,0 +1,25 @@
+# Identidade Visual
+
+Este documento descreve o padrão de componentes e a estilização do HemoseSystem.
+
+## Cores
+- **Primária (`#B91C1C`)**: utilizada em botões, cabeçalhos e elementos de destaque.
+- **Secundária (`#111827`)**: cor principal de textos.
+- **Realce (`#2563EB`)**: usada para links e ações secundárias.
+- **Fundo (`#F8FAFC`)**: cor de fundo padrão das páginas.
+
+## Tipografia
+- **Poppins** para títulos e elementos de destaque.
+- **Inter** para textos e conteúdo geral.
+
+## Componentes
+- Botões e campos possuem bordas arredondadas (`rounded-md`).
+- Navegação (navbar e sidebar) utiliza a cor primária com textos em branco.
+- As páginas utilizam a cor de fundo `background` definida no `tailwind.config.js`.
+
+## Estilos Globais
+- TailwindCSS define as utilidades e as classes personalizadas.
+- As fontes são importadas em `root.tsx`.
+- O arquivo `input.css` aplica as fontes e cores base ao `body` e aos cabeçalhos.
+
+Todos os componentes devem seguir essas diretrizes para garantir consistência visual.

--- a/front/app/components/GenericFilter.tsx
+++ b/front/app/components/GenericFilter.tsx
@@ -29,6 +29,7 @@ export const GenericFilter: React.FC<GenericFilterProps> = ({
       <Select
         label="Filtrar por"
         size='sm'
+        className='rounded-md'
         selectedKeys={selectedColumn ? [selectedColumn] : []}
         onSelectionChange={(keys) => {
           const selected = Array.from(keys)[0] as string;
@@ -46,7 +47,7 @@ export const GenericFilter: React.FC<GenericFilterProps> = ({
         value={filterValue}
         onValueChange={onFilterChange}
         placeholder={placeholder}
-        className='col-span-2'
+        className='col-span-2 rounded-md'
         startContent={<MagnifyingGlassIcon className="w-4 h-4 text-gray-400" />}
         size="lg"
         disabled={!selectedColumn}

--- a/front/app/components/header/header.tsx
+++ b/front/app/components/header/header.tsx
@@ -30,13 +30,13 @@ interface HeaderProps {
 
 export default function Header({ onMenuToggle }: HeaderProps) {
   return (
-    <Navbar className="shadow-md" maxWidth="full" >
+    <Navbar className="shadow-md bg-primary text-white" maxWidth="full" >
       <NavbarContent justify="start">
         <Button
           isIconOnly
-          color="primary"
+          color="secondary"
           onPress={onMenuToggle}
-          className="text-default-500"
+          className="text-white"
         >
           <Bars3Icon className="h-6 w-6 text-white" />
         </Button>
@@ -53,7 +53,7 @@ export default function Header({ onMenuToggle }: HeaderProps) {
       <NavbarContent as="div" justify="end">
         <Dropdown placement="bottom-end">
           <DropdownTrigger>
-            <Button isIconOnly color="primary">
+            <Button isIconOnly color="secondary" className="text-white">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
               </svg>

--- a/front/app/components/main-layout/main-layout.tsx
+++ b/front/app/components/main-layout/main-layout.tsx
@@ -12,7 +12,7 @@ export default function MainLayout() {
 
   return (
     
-    <div className="min-h-screen bg-[#F0F4F7]">
+    <div className="min-h-screen bg-background">
       <Header onMenuToggle={handleMenuToggle} />
       <SidebarMenu isOpen={isOpen} onOpenChange={setIsOpen} />
       <main className="flex-1 p-6">

--- a/front/app/components/sidebar-menu/sidebar-menu.tsx
+++ b/front/app/components/sidebar-menu/sidebar-menu.tsx
@@ -34,8 +34,8 @@ const menuItems = [
 export default function SidebarMenu({ isOpen, onOpenChange }: SidebarMenuProps) {
   return (
   
-    <Drawer 
-      isOpen={isOpen} 
+    <Drawer
+      isOpen={isOpen}
       onOpenChange={onOpenChange}
       backdrop="transparent"
       placement="left"
@@ -43,7 +43,7 @@ export default function SidebarMenu({ isOpen, onOpenChange }: SidebarMenuProps) 
       defaultOpen={true}
       classNames={{
         backdrop: "bg-opacity-0",
-        base: "bg-content1"
+        base: "bg-primary text-white",
       }}
     >
       <DrawerContent>
@@ -57,8 +57,8 @@ export default function SidebarMenu({ isOpen, onOpenChange }: SidebarMenuProps) 
                 key={item.path}
                 as={RouteLink}
                 to={item.path}
-                variant="flat"
-                className="justify-start"
+                variant="light"
+                className="justify-start text-white hover:bg-white/10"
                 startContent={<item.icon className="h-5 w-5" />}
                 onPress={() => onOpenChange(false)}
               >

--- a/front/app/input.css
+++ b/front/app/input.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans bg-background text-secondary;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-display text-secondary;
+  }
+}

--- a/front/app/pages/auth/cadastro/cadastro.tsx
+++ b/front/app/pages/auth/cadastro/cadastro.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { Selection } from "@react-types/shared";
 import { 
   Button, 
   Input, 
@@ -37,11 +38,11 @@ const councilMap: Record<string, string> = {
 
 export function Cadastro() {
   // Remova o useState do isHealthProfessional
-  const [selectedRole, setSelectedRole] = React.useState<Set<string>>(new Set([]));
+  const [selectedRole, setSelectedRole] = React.useState<Selection>(new Set([]));
   const [council, setCouncil] = React.useState("");
   const [createUser, { isLoading }] = useCreateUserMutation();
 
-  const handleRoleChange = (keys: "all" | Set<string>) => {
+  const handleRoleChange = (keys: Selection) => {
     if (keys === "all" || !(keys instanceof Set)) {
       return;
     }
@@ -51,7 +52,7 @@ export function Cadastro() {
     setCouncil(councilMap[roleKey] || "");
   };
 
-  const selectedRoleKey = Array.from(selectedRole)[0];
+  const selectedRoleKey = selectedRole && selectedRole !== 'all' ? Array.from(selectedRole as Set<string>)[0] : '';
   const isHealthProfessional = healthRoles.includes(selectedRoleKey);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -66,7 +67,7 @@ export function Cadastro() {
       especialidade: formData.get("especialidade") as string || undefined,
       conselho: council || undefined,
       registro: formData.get("registro") as string || undefined,
-      roles: selectedRole ? Array.from(selectedRole): undefined,
+      roles: selectedRole && selectedRole !== 'all' ? Array.from(selectedRole as Set<string>) : undefined,
     };
 
     try {

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -24,6 +24,10 @@ export const links: Route.LinksFunction = () => [
     rel: "stylesheet",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
+  {
+    rel: "stylesheet",
+    href: "https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700&display=swap",
+  },
 ];
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -8,7 +8,18 @@ module.exports = {
     "./node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: "#B91C1C",
+        secondary: "#111827",
+        accent: "#2563EB",
+        background: "#F8FAFC",
+      },
+      fontFamily: {
+        sans: ["Inter", "sans-serif"],
+        display: ["Poppins", "Inter", "sans-serif"],
+      },
+    },
   },
   darkMode: "class",
   plugins: [heroui()],


### PR DESCRIPTION
## Summary
- cria documento de identidade visual
- define paleta de cores e fontes no Tailwind
- aplica estilos globais no `input.css`
- ajusta Header, SidebarMenu, MainLayout e filtros
- corrige tipos em `cadastro` para o typecheck passar

## Testing
- `npm run build` no frontend
- `npm run typecheck` no frontend
- `npm run generate` no backend *(falhou: 403 Forbidden)*
- `npx tsc --noEmit` no backend *(falhou por falta do prisma client)*


------
https://chatgpt.com/codex/tasks/task_e_68473065d6c0832aaf21540ae0155805