### PR TITLE
Melhoria na home com cards de navegação

### DIFF
--- a/front/app/components/home/FeatureCard.tsx
+++ b/front/app/components/home/FeatureCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+interface FeatureCardProps {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  title: string;
+  description: string;
+  path: string;
+}
+
+const FeatureCard: React.FC<FeatureCardProps> = ({ icon: Icon, title, description, path }) => {
+  return (
+    <Link
+      viewTransition
+      to={path}
+      className="flex flex-col items-center bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-6 text-center"
+    >
+      <Icon className="h-10 w-10 text-primary mb-4" />
+      <h3 className="text-lg font-semibold mb-1">{title}</h3>
+      <p className="text-sm text-gray-500">{description}</p>
+    </Link>
+  );
+};
+
+export default FeatureCard;

--- a/front/app/components/home/FeatureCard.tsx
+++ b/front/app/components/home/FeatureCard.tsx
@@ -1,14 +1,26 @@
 import React from 'react';
 import { Link } from 'react-router';
 
+interface Metric {
+  label: string;
+  value: number;
+}
+
 interface FeatureCardProps {
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   title: string;
   description: string;
   path: string;
+  metrics?: Metric[];
 }
 
-const FeatureCard: React.FC<FeatureCardProps> = ({ icon: Icon, title, description, path }) => {
+const FeatureCard: React.FC<FeatureCardProps> = ({
+  icon: Icon,
+  title,
+  description,
+  path,
+  metrics,
+}) => {
   return (
     <Link
       viewTransition
@@ -17,7 +29,17 @@ const FeatureCard: React.FC<FeatureCardProps> = ({ icon: Icon, title, descriptio
     >
       <Icon className="h-10 w-10 text-primary mb-4" />
       <h3 className="text-lg font-semibold mb-1">{title}</h3>
-      <p className="text-sm text-gray-500">{description}</p>
+      <p className="text-sm text-gray-500 mb-2">{description}</p>
+      {metrics && (
+        <div className="space-y-1 text-sm">
+          {metrics.map((m) => (
+            <div key={m.label} className="flex justify-between w-full">
+              <span className="text-gray-500">{m.label}</span>
+              <span className="font-semibold text-primary">{m.value}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </Link>
   );
 };

--- a/front/app/components/home/FeatureCard.tsx
+++ b/front/app/components/home/FeatureCard.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Link } from 'react-router';
+import React from "react";
+import { Link } from "react-router";
+import { Card, CardHeader, CardBody, Badge } from "@heroui/react";
 
 interface Metric {
   label: string;
@@ -22,24 +23,26 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
   metrics,
 }) => {
   return (
-    <Link
-      viewTransition
-      to={path}
-      className="flex flex-col items-center bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-6 text-center"
-    >
-      <Icon className="h-10 w-10 text-primary mb-4" />
-      <h3 className="text-lg font-semibold mb-1">{title}</h3>
-      <p className="text-sm text-gray-500 mb-2">{description}</p>
-      {metrics && (
-        <div className="space-y-1 text-sm">
-          {metrics.map((m) => (
-            <div key={m.label} className="flex justify-between w-full">
-              <span className="text-gray-500">{m.label}</span>
-              <span className="font-semibold text-primary">{m.value}</span>
-            </div>
-          ))}
-        </div>
-      )}
+    <Link viewTransition to={path} className="block">
+      <Card className="h-full hover:shadow-lg transition-shadow">
+        <CardHeader className="flex flex-col items-center gap-1 text-center">
+          <Icon className="h-10 w-10 text-primary" />
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <p className="text-sm text-gray-500">{description}</p>
+        </CardHeader>
+        {metrics && metrics.length > 0 && (
+          <CardBody className="space-y-2 text-sm">
+            {metrics.map((m) => (
+              <div key={m.label} className="flex justify-between items-center">
+                <span className="text-gray-500">{m.label}</span>
+                <Badge color="primary" variant="flat" size="sm">
+                  {m.value}
+                </Badge>
+              </div>
+            ))}
+          </CardBody>
+        )}
+      </Card>
     </Link>
   );
 };

--- a/front/app/pages/auth/cadastro/cadastro.tsx
+++ b/front/app/pages/auth/cadastro/cadastro.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { 
+import {
   Button, 
   Input, 
   Link, 
@@ -14,6 +14,7 @@ import {
 } from "@heroui/react";
 import { useCreateUserMutation } from "~/services/siahme-api.service";
 import { CreateUserDto } from "~/Dtos/User/CreateUser.dto";
+import type { Selection } from "@react-types/shared";
 
 const roles = [
   { name: "gestor", description: "Gestor" },
@@ -41,13 +42,13 @@ export function Cadastro() {
   const [council, setCouncil] = React.useState("");
   const [createUser, { isLoading }] = useCreateUserMutation();
 
-  const handleRoleChange = (keys: "all" | Set<string>) => {
+  const handleRoleChange = (keys: Selection) => {
     if (keys === "all" || !(keys instanceof Set)) {
       return;
     }
 
-    setSelectedRole(keys);
-    const roleKey = Array.from(keys)[0];
+    setSelectedRole(keys as Set<string>);
+    const roleKey = Array.from(keys)[0] as string;
     setCouncil(councilMap[roleKey] || "");
   };
 

--- a/front/app/pages/home/home.tsx
+++ b/front/app/pages/home/home.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import FeatureCard from "~/components/home/FeatureCard";
 import {
   CalendarDaysIcon,
@@ -5,34 +6,112 @@ import {
   FolderOpenIcon,
   UsersIcon,
   UserGroupIcon,
-  ShieldCheckIcon
+  ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
+import {
+  useGetAgendamentosByDateQuery,
+  useGetAgendamentosComConsultasAtivasQuery,
+  useGetAgendamentosNaEnfermariaQuery,
+} from "~/services/siahme-api.service";
+import {
+  StatusAgendamentoEnum,
+  status_consulta_enum,
+} from "~/utils/enums/enums";
 
 export function Home() {
+  const today = new Date().toISOString().split("T")[0];
+  const { data: todaysAppointments = [] } = useGetAgendamentosByDateQuery({
+    date: today,
+  });
+  const { data: activeAppointments = [] } =
+    useGetAgendamentosComConsultasAtivasQuery();
+  const { data: enfermariaAppointments = [] } =
+    useGetAgendamentosNaEnfermariaQuery();
+
+  const recepcaoTotal = React.useMemo(
+    () =>
+      todaysAppointments.filter(
+        (a) =>
+          a.status_agendamento !== StatusAgendamentoEnum.Cancelado &&
+          a.status_agendamento !== StatusAgendamentoEnum.Reagendado &&
+          a.status_agendamento !== StatusAgendamentoEnum.Realizado
+      ).length,
+    [todaysAppointments]
+  );
+
+  const waitingConsultas = React.useMemo(
+    () =>
+      activeAppointments.filter(
+        (a) =>
+          a.Consulta &&
+          (a.Consulta.status === status_consulta_enum.AGUARDANDO ||
+            a.Consulta.status === status_consulta_enum.CHAMADO)
+      ).length,
+    [activeAppointments]
+  );
+
+  const inProgressConsultas = React.useMemo(
+    () =>
+      activeAppointments.filter(
+        (a) =>
+          a.Consulta && a.Consulta.status === status_consulta_enum.EM_ATENDIMENTO
+      ).length,
+    [activeAppointments]
+  );
+
+  const aguardandoAcolhimento = React.useMemo(
+    () =>
+      enfermariaAppointments.filter(
+        (a) =>
+          a.Consulta &&
+          a.Consulta.status === status_consulta_enum.AGUARDANDO_ACOLHIMENTO
+      ).length,
+    [enfermariaAppointments]
+  );
+
+  const naEnfermaria = React.useMemo(
+    () =>
+      enfermariaAppointments.filter(
+        (a) =>
+          a.Consulta && a.Consulta.status === status_consulta_enum.ENFERMARIA
+      ).length,
+    [enfermariaAppointments]
+  );
   const features = [
     {
       title: "Recepção",
       description: "Agendamentos e cadastro de pacientes",
       icon: CalendarDaysIcon,
       path: "/recepcao",
+      metrics: [
+        { label: "Agendamentos hoje", value: recepcaoTotal },
+      ],
     },
     {
       title: "Consultas",
       description: "Gerencie pacientes em atendimento",
       icon: ClipboardDocumentListIcon,
       path: "/selecao-agendamento",
-    },
-    {
-      title: "Prontuários",
-      description: "Histórico médico dos pacientes",
-      icon: FolderOpenIcon,
-      path: "/prontuarios",
+      metrics: [
+        { label: "Aguardando", value: waitingConsultas },
+        { label: "Em atendimento", value: inProgressConsultas },
+      ],
     },
     {
       title: "Enfermaria",
       description: "Controle de pacientes internados",
       icon: UsersIcon,
       path: "/enfermaria",
+      metrics: [
+        { label: "Aguard. acolhimento", value: aguardandoAcolhimento },
+        { label: "Na enfermaria", value: naEnfermaria },
+      ],
+    },
+    {
+      title: "Prontuários",
+      description: "Histórico médico dos pacientes",
+      icon: FolderOpenIcon,
+      path: "/prontuarios",
     },
     {
       title: "Funcionários",

--- a/front/app/pages/home/home.tsx
+++ b/front/app/pages/home/home.tsx
@@ -1,7 +1,64 @@
+import FeatureCard from "~/components/home/FeatureCard";
+import {
+  CalendarDaysIcon,
+  ClipboardDocumentListIcon,
+  FolderOpenIcon,
+  UsersIcon,
+  UserGroupIcon,
+  ShieldCheckIcon
+} from "@heroicons/react/24/outline";
+
 export function Home() {
+  const features = [
+    {
+      title: "Recepção",
+      description: "Agendamentos e cadastro de pacientes",
+      icon: CalendarDaysIcon,
+      path: "/recepcao",
+    },
+    {
+      title: "Consultas",
+      description: "Gerencie pacientes em atendimento",
+      icon: ClipboardDocumentListIcon,
+      path: "/selecao-agendamento",
+    },
+    {
+      title: "Prontuários",
+      description: "Histórico médico dos pacientes",
+      icon: FolderOpenIcon,
+      path: "/prontuarios",
+    },
+    {
+      title: "Enfermaria",
+      description: "Controle de pacientes internados",
+      icon: UsersIcon,
+      path: "/enfermaria",
+    },
+    {
+      title: "Funcionários",
+      description: "Cadastro e permissões",
+      icon: UserGroupIcon,
+      path: "/funcionarios",
+    },
+    {
+      title: "Permissões",
+      description: "Gerencie roles e permissões",
+      icon: ShieldCheckIcon,
+      path: "/admin/permissions",
+    },
+  ];
+
   return (
-    <>
-      <h1>TESTE</h1>
-    </>
+    <div className="container mx-auto p-6 max-w-7xl">
+      <div className="text-center mb-12">
+        <h1 className="text-3xl font-bold mb-2">Bem-vindo ao HemoseSystem</h1>
+        <p className="text-gray-600">Selecione um módulo para começar</p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {features.map((feature) => (
+          <FeatureCard key={feature.title} {...feature} />
+        ))}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- cria componente `FeatureCard` reutilizável
- implementa home com grid de navegação
- corrige tipagem no cadastro para passar no typecheck

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684970b0a8fc832a9109414ad1ab1b9f